### PR TITLE
Basic Windows platform support

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -24,8 +24,11 @@ def append_venv_path(virtual_env: str):
     if not lib_dir.exists():
         log("WARN", f"Virtual environment does not have lib directory: {lib_dir}")
         return
-    python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
-    python_dir = lib_dir / f"python{python_ver}"
+    if os.name == "nt":
+        python_dir = lib_dir
+    else:
+        python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+        python_dir = lib_dir / f"python{python_ver}"
     if not python_dir.exists():
         log(
             "WARN",

--- a/lua/blender/profile/detect.lua
+++ b/lua/blender/profile/detect.lua
@@ -18,7 +18,10 @@ return function()
     execs['Blender.app'] = '/Applications/Blender.app/Contents/MacOS/Blender'
     table.insert(search_paths, '/opt/homebrew/bin')
   end
-  -- TODO: Windows
+  local is_windows = vim.fn.has 'win32' == 1
+  if is_windows then
+    table.insert(search_paths, 'C:/Program Files/Blender Foundation')
+  end
 
   ---@type ProfileParams[]
   local profiles = {}
@@ -28,6 +31,9 @@ return function()
       unpack(name:sub(1, 1) == '/' and {} or search_paths),
     } do
       local full_path = path == '' and exec or path .. '/' .. exec
+      if is_windows then
+        full_path = path .. '/' .. name .. '/blender'
+      end
       local exec_path = vim.fn.exepath(full_path)
       if exec_path ~= '' then
         ---@type ProfileParams

--- a/lua/blender/profile/init.lua
+++ b/lua/blender/profile/init.lua
@@ -28,6 +28,11 @@ local get_launcher_path = function()
   return launcher_path[1]
 end
 
+local fix_path_separators = function(path)
+  -- Windows paths get mixed up, ensure they have consistent separators
+  return vim.fn.has('win32') == 1 and string.gsub(path, '\\', '/') or path
+end
+
 ---@param params ProfileParams
 ---@return Profile
 function Profile.create(params)
@@ -96,6 +101,7 @@ function Profile:get_full_cmd()
 end
 
 local function is_addon_init(path)
+  path = fix_path_separators(path)
   if vim.fn.filereadable(path) == 0 then
     return false
   end
@@ -147,7 +153,7 @@ end
 function Profile:get_watch_patterns()
   local paths = self:get_paths()
   -- TODO: Make this configurable
-  local addon_dir = paths.addon_dir
+  local addon_dir = fix_path_separators(paths.addon_dir)
   return { addon_dir .. '/*' }
 end
 


### PR DESCRIPTION
First off, great plugin, it's been superb for iteration speed!
I recently had to set it up in a Windows 11 environment for one project, and ran across a couple of issues.
The ones I found are outlined below, and I've made some very basic quick fixes to handle them in this PR.

- In the windows python context, it turns out that the virtualenvs have a slightly different structure, omitting the version directory above `site-packages`, as well as using Scripts over bin, etc. (looks like mostly due to legacy reasons: https://peps.python.org/pep-0250/)
- Windows default installs can be a bit all over the place, I only added the default installer path from the default blender installer to get profile detection working. I'm guessing that it might differ if installed via the "Windows Store" etc, but I don't have it enabled on this setup to be able to test. Either way, even without profile detection, if some blender install is on the path then it'll be able to launch.
- Windows paths get mixed separators as the built in vim functions return with windows-style separators on that platform, which leads to the file watching not workng. Using full windows-style paths seem to not work well for all commands, however simply ensuring that all paths are unix-style works well as vim then handles that under the hood.

I've tested some basic workflows and the dap setup, it seems to run fine now.
This was mostly a quick fix on my side so no great thought went into implementation, feel free to do whatever you want with it.