### PR TITLE
fix: replace vim.tbl_islist with vim.islist

### DIFF
--- a/lua/blender/config/validate.lua
+++ b/lua/blender/config/validate.lua
@@ -214,7 +214,7 @@ M.number.natural = M.all { M.number._int, M.number._ge(1) }
 -- percentages are numbers between 0 and 1, inclusive
 M.number.percentage = M.number._between_r_inc(0, 1)
 
-M.list = wrapped(vim.tbl_islist)
+M.list = wrapped(vim.islist)
 
 M.list.of = function(of)
   return function(val)


### PR DESCRIPTION
After installing blender.nvim I got the `vim.tbl_islist is depracated` error. I checked the docs and it's required to replace it with `vim.islist`.